### PR TITLE
DiagID Control packet Handling

### DIFF
--- a/router/diag.h
+++ b/router/diag.h
@@ -59,9 +59,14 @@
 #define DIAG_FEATURE_DCI_EXTENDED_HEADER			BIT(14)
 #define DIAG_FEATURE_DIAG_ID					BIT(15)
 #define DIAG_FEATURE_PKT_HEADER_UNTAG				BIT(16)
+#define DIAG_FEATURE_DIAG_ID_FEATURE_MASK			BIT(19)
 
 #define DIAG_CMD_SUBSYS_DISPATCH       75
 #define DIAG_CMD_SUBSYS_DISPATCH_V2	128
+
+#define DIAG_MAX_REQ_SIZE	(16 * 1024)
+#define DIAG_MAX_RSP_SIZE	(16 * 1024)
+#define DIAG_ID_APPS 1
 
 struct diag_client;
 
@@ -88,6 +93,8 @@ struct peripheral {
 	int diag_id;
 
 	bool sockets;
+
+	uint8_t diagid_v2_feature_flag;
 
 	struct circ_buf recv_buf;
 	struct hdlc_decoder recv_decoder;

--- a/router/diag_cntl.h
+++ b/router/diag_cntl.h
@@ -35,6 +35,23 @@
 #include "peripheral.h"
 #include "masks.h"
 
+struct diag_id_tbl_t {
+	struct list_head link;
+	uint8_t diag_id;
+	uint8_t pd_val;
+	uint32_t periph_id;
+	uint8_t pd_feature_mask;
+	char *process_name;
+} __packed;
+
+struct diag_id_t {
+	uint8_t diag_id;
+	uint8_t len;
+	char *process_name;
+} __packed;
+
+extern struct list_head g_diag_id_list;
+
 int diag_cntl_recv(struct peripheral *perif, const void *buf, size_t len);
 void diag_cntl_send_log_mask(struct peripheral *peripheral, uint32_t equip_id);
 void diag_cntl_send_msg_mask(struct peripheral *peripheral, struct diag_ssid_range_t *range);


### PR DESCRIPTION
Add support for DiagID V1, V2 and V3 Control Packet definitions and subsequent feature handling.

This change has been validated on Lemans(KLM).
![image](https://github.com/user-attachments/assets/d7356ff6-0005-4ffd-9015-a2ec8a221eef)
